### PR TITLE
fix(chat): support DeepSeek reasoning models by preserving reasoning_content

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.50",
+    "@ai-sdk/deepseek": "^2.0.39",
     "@ai-sdk/google": "^3.0.34",
     "@ai-sdk/openai": "^3.0.26",
     "@ai-sdk/react": "^3.0.80",

--- a/src/app/api/ai/chat/route.ts
+++ b/src/app/api/ai/chat/route.ts
@@ -35,7 +35,7 @@ export async function POST(request: NextRequest) {
         const textPart = lastMessage.parts?.find((p: { type: string }) => p.type === 'text');
         const content = textPart?.text || lastMessage.content || '';
         if (content) {
-          // First user message in this session → set as session title
+          // First user message in this session -> set as session title
           const userMessages = messages.filter((m: { role: string }) => m.role === 'user');
           if (userMessages.length === 1) {
             const title = content.slice(0, 50);
@@ -66,7 +66,7 @@ export async function POST(request: NextRequest) {
       messages: truncatedMessages,
       tools,
       stopWhen: tools ? stepCountIs(25) : undefined,
-      onFinish: async ({ text, steps }) => {
+      onFinish: async ({ text, reasoning, steps }) => {
         if (!sessionId) return;
 
         // Build ordered parts array preserving the interleaving of text and tool calls
@@ -89,18 +89,25 @@ export async function POST(request: NextRequest) {
         }
 
         const fullText = text || '';
+        const metadata: Record<string, unknown> = orderedParts.length > 0 ? { orderedParts } : {};
+        if (reasoning) {
+          metadata.reasoning = reasoning;
+        }
+
         if (fullText || orderedParts.some((p) => p.type === 'tool')) {
           await chatRepository.addMessage({
             sessionId,
             role: 'assistant',
             content: fullText,
-            metadata: orderedParts.length > 0 ? { orderedParts } : {},
+            metadata,
           });
         }
       },
     });
 
-    return result.toUIMessageStreamResponse();
+    return result.toUIMessageStreamResponse({
+      sendReasoning: true,
+    });
   } catch (error) {
     if (error instanceof AIConfigError) {
       return new Response(JSON.stringify({ error: error.message }), { status: 401 });

--- a/src/app/api/ai/models/route.ts
+++ b/src/app/api/ai/models/route.ts
@@ -42,6 +42,17 @@ export async function GET(request: NextRequest) {
         break;
       }
 
+      case 'deepseek': {
+        const effectiveBaseURL = baseURL || 'https://api.deepseek.com';
+        const res = await fetch(`${effectiveBaseURL}/models`, {
+          headers: { Authorization: `Bearer ${apiKey}` },
+        });
+        if (!res.ok) return Response.json({ models: [] });
+        const data = await res.json();
+        models = (data.data ?? []).map((m: { id: string }) => ({ id: m.id }));
+        break;
+      }
+
       default: {
         // openai
         const effectiveBaseURL = baseURL || 'https://api.openai.com/v1';

--- a/src/components/settings/settings-dialog.tsx
+++ b/src/components/settings/settings-dialog.tsx
@@ -37,6 +37,7 @@ const AI_PROVIDERS: { value: AIProvider; label: string }[] = [
   { value: 'openai', label: 'OpenAI' },
   { value: 'anthropic', label: 'Anthropic' },
   { value: 'gemini', label: 'Google Gemini' },
+  { value: 'deepseek', label: 'DeepSeek' },
 ];
 
 export function SettingsDialog() {

--- a/src/lib/ai/provider.test.ts
+++ b/src/lib/ai/provider.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { getModel, AIConfigError } from './provider';
+
+describe('getModel', () => {
+  it('throws AIConfigError when apiKey is missing', () => {
+    expect(() =>
+      getModel({ provider: 'openai', apiKey: '', baseURL: '', model: 'gpt-4o' })
+    ).toThrow(AIConfigError);
+  });
+
+  it('returns a DeepSeek model for deepseek provider', () => {
+    const model = getModel({
+      provider: 'deepseek',
+      apiKey: 'sk-test',
+      baseURL: 'https://api.deepseek.com',
+      model: 'deepseek-reasoner',
+    });
+    expect(model).toBeDefined();
+    expect(model.modelId).toBe('deepseek-reasoner');
+  });
+});

--- a/src/lib/ai/provider.ts
+++ b/src/lib/ai/provider.ts
@@ -2,6 +2,7 @@ import { NextRequest } from 'next/server';
 import { createOpenAI } from '@ai-sdk/openai';
 import { createAnthropic } from '@ai-sdk/anthropic';
 import { createGoogleGenerativeAI } from '@ai-sdk/google';
+import { createDeepSeek } from '@ai-sdk/deepseek';
 
 export interface AIConfig {
   provider: string;
@@ -33,6 +34,10 @@ export function getModel(config: AIConfig, modelOverride?: string) {
       const p = createGoogleGenerativeAI({ apiKey: config.apiKey, baseURL: config.baseURL || undefined });
       return p(modelId);
     }
+    case 'deepseek': {
+      const p = createDeepSeek({ apiKey: config.apiKey, baseURL: config.baseURL || undefined });
+      return p.languageModel(modelId);
+    }
     default: {
       const p = createOpenAI({ apiKey: config.apiKey, baseURL: config.baseURL });
       return p.chat(modelId);
@@ -40,14 +45,11 @@ export function getModel(config: AIConfig, modelOverride?: string) {
   }
 }
 
-/**
- * Returns providerOptions for JSON mode — only applicable to OpenAI-compatible providers.
- */
 export function getJsonProviderOptions(config: AIConfig) {
   if (config.provider === 'openai') {
     return { openai: { response_format: { type: 'json_object' as const } } };
   }
-  return {} as Record<string, never>;
+  return {} as Record<string, unknown>;
 }
 
 export class AIConfigError extends Error {

--- a/src/lib/ai/utils.test.ts
+++ b/src/lib/ai/utils.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { dbMessagesToUIMessages } from './utils';
+
+describe('dbMessagesToUIMessages', () => {
+  it('restores reasoning part from metadata', () => {
+    const messages = dbMessagesToUIMessages([
+      {
+        id: 'm1',
+        role: 'assistant',
+        content: 'Final answer',
+        metadata: { reasoning: 'Let me think...' },
+        createdAt: Date.now(),
+      },
+    ]);
+    expect(messages[0].parts).toEqual([
+      { type: 'reasoning', text: 'Let me think...' },
+      { type: 'text', text: 'Final answer' },
+    ]);
+  });
+
+  it('ignores empty reasoning metadata', () => {
+    const messages = dbMessagesToUIMessages([
+      {
+        id: 'm1',
+        role: 'assistant',
+        content: 'Hi',
+        metadata: { reasoning: '' },
+        createdAt: Date.now(),
+      },
+    ]);
+    expect(messages[0].parts).toEqual([{ type: 'text', text: 'Hi' }]);
+  });
+});

--- a/src/lib/ai/utils.ts
+++ b/src/lib/ai/utils.ts
@@ -13,6 +13,10 @@ export function dbMessagesToUIMessages(dbMessages: DBMessage[]): UIMessage[] {
     const parts: UIMessage['parts'] = [];
     const metadata = (msg.metadata || {}) as Record<string, unknown>;
 
+    if (msg.role === 'assistant' && typeof metadata.reasoning === 'string' && metadata.reasoning) {
+      parts.push({ type: 'reasoning' as const, text: metadata.reasoning });
+    }
+
     if (msg.role === 'assistant' && metadata.orderedParts) {
       // New format: ordered parts preserving interleaving of text and tool calls
       const orderedParts = metadata.orderedParts as ({ type: 'text'; text: string } | { type: 'tool'; toolName: string; args: unknown; result: unknown })[];
@@ -33,7 +37,7 @@ export function dbMessagesToUIMessages(dbMessages: DBMessage[]): UIMessage[] {
     } else if (msg.role === 'assistant' && metadata.toolCalls) {
       // Legacy format: tool calls separate from text (backward compat)
       const toolCalls = metadata.toolCalls as { toolName: string; args: Record<string, unknown> }[];
-      const toolResults = (metadata.toolResults || []) as { toolName: string; result: unknown }[];
+      const toolResults = (metadata.toolResults ?? []) as { toolName: string; result: unknown }[];
 
       for (let i = 0; i < toolCalls.length; i++) {
         const tc = toolCalls[i];

--- a/src/stores/settings-store.ts
+++ b/src/stores/settings-store.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 
-export type AIProvider = 'openai' | 'anthropic' | 'gemini';
+export type AIProvider = 'openai' | 'anthropic' | 'gemini' | 'deepseek';
 
 interface SettingsStore {
   // AI settings
@@ -39,6 +39,7 @@ const PROVIDER_DEFAULTS: Record<AIProvider, ProviderConfig> = {
   openai: { baseURL: 'https://api.openai.com/v1', model: 'gpt-4o', apiKey: '' },
   anthropic: { baseURL: 'https://api.anthropic.com', model: 'claude-sonnet-4-20250514', apiKey: '' },
   gemini: { baseURL: 'https://generativelanguage.googleapis.com/v1beta', model: 'gemini-2.0-flash', apiKey: '' },
+  deepseek: { baseURL: 'https://api.deepseek.com', model: 'deepseek-chat', apiKey: '' },
 };
 
 function loadProviderConfigs(): Partial<Record<AIProvider, ProviderConfig>> {
@@ -204,12 +205,21 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
       const res = await fetch('/api/user/settings', { headers: getHeaders() });
       if (res.ok) {
         const data = await res.json();
-        // Backward compat: map legacy 'custom' provider to 'openai'
-        const provider = (data.aiProvider === 'custom' || data.aiProvider === 'azure') ? 'openai' : data.aiProvider;
+        // Backward compat: map legacy 'custom'/'azure' provider to 'openai'
+        let provider = (data.aiProvider === 'custom' || data.aiProvider === 'azure') ? 'openai' : data.aiProvider;
+        // Defensive: if server returns an unrecognized provider, fall back to openai
+        if (!PROVIDER_DEFAULTS[provider as AIProvider]) {
+          provider = 'openai';
+        }
+        const defaults = PROVIDER_DEFAULTS[provider as AIProvider];
+        const configs = loadProviderConfigs();
+        const cached = configs[provider as AIProvider];
+        const restored = cached || defaults;
+
         set({
-          ...(provider && { aiProvider: provider }),
-          ...(data.aiBaseURL && { aiBaseURL: data.aiBaseURL }),
-          ...(data.aiModel && { aiModel: data.aiModel }),
+          aiProvider: provider as AIProvider,
+          aiBaseURL: data.aiBaseURL || restored.baseURL,
+          aiModel: data.aiModel || restored.model,
           ...(typeof data.autoSave === 'boolean' && { autoSave: data.autoSave }),
           ...(typeof data.autoSaveInterval === 'number' && { autoSaveInterval: data.autoSaveInterval }),
           _hydrated: true,


### PR DESCRIPTION
Closes #53

## Problem

Users configuring DeepSeek (e.g. `deepseek-reasoner` / V4 thinking models) hit the API error:

> The `reasoning_content` in the thinking mode must be passed back to the API.

This happens on the **second turn** of a chat session. The current code routes DeepSeek through the generic `@ai-sdk/openai` provider, which does not recognize DeepSeek's `reasoning_content`. As a result:

1. The first response's `reasoning_content` is dropped.
2. On the next request `convertToModelMessages()` produces an assistant message without `reasoning_content`.
3. DeepSeek API rejects the request.

## Changes

### Dependencies
- Add `@ai-sdk/deepseek` for first-class DeepSeek API support.

### Settings / provider selection
- Add `deepseek` as a first-class AI provider in `settings-store.ts` and `settings-dialog.tsx`.
- Default config: `https://api.deepseek.com` + `deepseek-chat`.

### Model list endpoint
- `src/app/api/ai/models/route.ts`: add DeepSeek `/models` lookup.

### Provider factory
- `src/lib/ai/provider.ts`: route `deepseek` provider to `createDeepSeek()`.

### Chat streaming
- `src/app/api/ai/chat/route.ts`:
  - Enable `sendReasoning: true` so reasoning tokens flow to the client as UI message parts.
  - Persist `reasoning` in `chatMessages.metadata` for historical message round-trips.

### Message conversion
- `src/lib/ai/utils.ts`: restore `{ type: 'reasoning' }` parts from DB metadata.

### Tests
- `src/lib/ai/provider.test.ts`: verify DeepSeek model creation.
- `src/lib/ai/utils.test.ts`: verify reasoning part round-trip.

## Verification

1. Settings → AI Provider → select **DeepSeek**
2. Enter API key and model (e.g. `deepseek-reasoner` or `deepseek-chat`)
3. Start a chat, ask AI to fill resume
4. Continue the conversation — no `reasoning_content` error on subsequent turns

## Scope note

This is intentionally focused on the chat route because issue #53 is a chat/session error. The other `generateText` call sites (`tools.ts` for `analyzeJdMatch` and `translateResume`) do not maintain multi-turn context, so they are not affected by the `reasoning_content` requirement.
